### PR TITLE
Update dependencies

### DIFF
--- a/__app__/requirements.in
+++ b/__app__/requirements.in
@@ -1,2 +1,2 @@
 gidgethub
-aiohttp==3.6.2
+aiohttp

--- a/__app__/requirements.in
+++ b/__app__/requirements.in
@@ -1,2 +1,2 @@
 gidgethub
-aiohttp
+aiohttp==3.6.2

--- a/__app__/requirements.txt
+++ b/__app__/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile '.\requirements.in'
 #
-aiohttp==3.5.4
+aiohttp==3.6.2
 async-timeout==3.0.1      # via aiohttp
 attrs==19.1.0             # via aiohttp
 chardet==3.0.4            # via aiohttp
-gidgethub==3.1.0
+gidgethub==3.3.0
 idna-ssl==1.1.0           # via aiohttp
 idna==2.8                 # via idna-ssl, yarl
 multidict==4.5.2          # via aiohttp, yarl

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -33,7 +33,7 @@ pytest==5.3.4
 six==1.12.0               # via packaging, pip-tools, pytest
 toml==0.10.0              # via black
 typing-extensions==3.7.2
-uritemplate==3.3.0
+uritemplate==3.0.1
 wcwidth==0.1.7            # via pytest
 yarl==1.3.0
 zipp==0.5.1               # via importlib-metadata

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,15 +4,14 @@
 #
 #    pip-compile '.\dev-requirements.in'
 #
-aiohttp==3.5.4
+aiohttp==3.6.2
 appdirs==1.4.3            # via black
 async-timeout==3.0.1
 asynctest==0.13.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0
-azure_storage==0.36.0
-azure-functions==1.0.0b4
-black==19.3b0
+azure-functions==1.0.7
+black==19.10b0
 chardet==3.0.4
 click==7.0                # via black, pip-tools
 colorama==0.4.1           # via pytest
@@ -24,16 +23,19 @@ importlib-resources==1.0.2
 more-itertools==7.0.0     # via pytest
 multidict==4.5.2
 packaging==19.0           # via pytest
+pathspec==0.7.0           # via black
 pip-tools==3.8.0
 pluggy==0.12.0            # via pytest
 py==1.8.0                 # via pytest
 pyparsing==2.4.0          # via packaging
 pytest-asyncio==0.10.0
 pytest==5.3.4
-six==1.12.0               # via packaging, pip-tools, pytest
+regex==2020.1.8           # via black
+six==1.12.0               # via packaging, pip-tools
 toml==0.10.0              # via black
+typed-ast==1.4.1          # via black
 typing-extensions==3.7.2
-uritemplate==3.0.1
+uritemplate==3.0.0
 wcwidth==0.1.7            # via pytest
 yarl==1.3.0
 zipp==0.5.1               # via importlib-metadata

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,12 +10,13 @@ async-timeout==3.0.1
 asynctest==0.13.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0
+azure_storage==0.36.0
 azure-functions==1.0.0b4
 black==19.3b0
 chardet==3.0.4
 click==7.0                # via black, pip-tools
 colorama==0.4.1           # via pytest
-gidgethub==3.1.0
+gidgethub==3.3.0
 idna-ssl==1.1.0
 idna==2.8
 importlib-metadata==0.18  # via pluggy, pytest
@@ -28,11 +29,11 @@ pluggy==0.12.0            # via pytest
 py==1.8.0                 # via pytest
 pyparsing==2.4.0          # via packaging
 pytest-asyncio==0.10.0
-pytest==4.6.3
+pytest==5.3.4
 six==1.12.0               # via packaging, pip-tools, pytest
 toml==0.10.0              # via black
 typing-extensions==3.7.2
-uritemplate==3.0.0
+uritemplate==3.3.0
 wcwidth==0.1.7            # via pytest
 yarl==1.3.0
 zipp==0.5.1               # via importlib-metadata


### PR DESCRIPTION
# Fixes Issue #40 

# Updated dependencies:
- aiohttp==3.6.2
- gidgethub==3.3.0
- azure-functions==1.0.7
- black==19.10b0
- pathspec==0.7.0
- pytest==5.3.4
- regex==2020.1.8
- six==1.12.0
- typed-ast==1.4.1 